### PR TITLE
Separate Pages and Navigation Bar

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,20 @@
+import Navigation from "./Navigation";
+import styled from "styled-components";
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Container>{children}</Container>
+      <Navigation />
+    </>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  margin: auto;
+  max-width: 60rem;
+  flex-direction: column;
+  padding: 5rem 1rem;
+  gap: 1rem;
+`;

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -1,11 +1,25 @@
 import Link from "next/link";
+import styled from "styled-components";
 
 export default function Navigation() {
   return (
-    <nav>
-      <Link href="/">Spotlight</Link>
-      <Link href="/art-pieces">All Art Pieces</Link>
-      <Link href="/">Favorites</Link>
-    </nav>
+    <StyledNavigation>
+      <StyledLink href="/">Spotlight</StyledLink>
+      <StyledLink href="/art-pieces">All Art Pieces</StyledLink>
+      <StyledLink href="/">Favorites</StyledLink>
+    </StyledNavigation>
   );
 }
+
+const StyledNavigation = styled.nav`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const StyledLink = styled(Link)`
+  background-color: gray;
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  color: white;
+  text-decoration: none;
+`;

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function Navigation() {
+  return (
+    <nav>
+      <Link href="/">Spotlight</Link>
+      <Link href="/art-pieces">All Art Pieces</Link>
+      <Link href="/">Favorites</Link>
+    </nav>
+  );
+}

--- a/components/Spotlight.js
+++ b/components/Spotlight.js
@@ -3,7 +3,6 @@ import { styled } from "styled-components";
 
 export default function Spotlight({ pieces }) {
   const index = Math.floor(Math.random() * pieces.length);
-  console.log(index);
   return (
     <StyledArticle key={pieces[index].slug}>
       <ImageWrapper>

--- a/components/Spotlight.js
+++ b/components/Spotlight.js
@@ -1,17 +1,39 @@
 import Image from "next/image";
+import { styled } from "styled-components";
 
 export default function Spotlight({ pieces }) {
   const index = Math.floor(Math.random() * pieces.length);
   console.log(index);
   return (
-    <article key={pieces[index].slug}>
-      <Image
-        src={pieces[index].imageSource}
-        height={300}
-        width={200}
-        alt={pieces[index].name}
-      />
+    <StyledArticle key={pieces[index].slug}>
+      <ImageWrapper>
+        <StyledImage
+          src={pieces[index].imageSource}
+          height={300}
+          width={200}
+          alt={pieces[index].name}
+        />
+      </ImageWrapper>
       <h3>{pieces[index].artist}</h3>
-    </article>
+      <p>Just a famous Artist for you...</p>
+    </StyledArticle>
   );
 }
+
+const StyledArticle = styled.article`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledImage = styled(Image)`
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+`;
+
+const ImageWrapper = styled.div`
+  background-color: blue;
+  width: 90%;
+  height: 60vh;
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "next": "13.4.8",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "styled-components": "^6.0.2",
+        "styled-components": "^6.0.5",
         "swr": "^2.2.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "next": "13.4.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "styled-components": "^6.0.2",
+    "styled-components": "^6.0.5",
     "swr": "^2.2.0"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import GlobalStyle from "../styles";
 import useSWR from "swr";
+import Layout from "@/components/Layout";
 
 const fetcher = async (url) => {
   const response = await fetch(url);
@@ -26,7 +27,9 @@ export default function App({ Component, pageProps }) {
   return (
     <>
       <GlobalStyle />
-      <Component {...pageProps} pieces={data} />
+      <Layout>
+        <Component {...pageProps} pieces={data} />
+      </Layout>
     </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,10 @@
 import Spotlight from "@/components/Spotlight";
-import Navigation from "@/components/Navigation";
 
 export default function SpotlightPage({ pieces }) {
   return (
     <>
       <h1>ART GALLERY</h1>
       <Spotlight pieces={pieces} />
-      <h2>Just a famous Artist for you</h2>
-      <Navigation />
     </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,13 @@
 import Spotlight from "@/components/Spotlight";
-import Link from "next/link";
+import Navigation from "@/components/Navigation";
 
-export default function HomePage({ pieces }) {
+export default function SpotlightPage({ pieces }) {
   return (
     <>
       <h1>ART GALLERY</h1>
       <Spotlight pieces={pieces} />
       <h2>Just a famous Artist for you</h2>
-      <Link href="./art-pieces">Go to all Art Pieces</Link>
+      <Navigation />
     </>
   );
 }

--- a/styles.js
+++ b/styles.js
@@ -5,10 +5,14 @@ export default createGlobalStyle`
   *::before,
   *::after {
     box-sizing: border-box;
+    margin: 0;
+    padding: 0;
   }
 
-  body {
-    margin: 0;
+  body, h1 {
+    margin: auto;
+    text-align: center;
+    width: 550px;
     font-family: system-ui;
   }
 `;


### PR DESCRIPTION
- Move the data fetching logic to pages/_app
-  Find a solution for global state handling to have the art pieces available on all pages
-  Adapt the page pages/index: rename the function to SpotlightPage and have it render only the Spotlight component
-  Create the page pages/art-pieces/index that renders the ArtPieces component
-  Create the component Navigation that renders all navigation links
-  Create the component Layout that renders the Navigation component
-  Apply the Layout component in pages/_app